### PR TITLE
Fix for ember 2.0

### DIFF
--- a/addon/support/before-observer.js
+++ b/addon/support/before-observer.js
@@ -1,0 +1,30 @@
+import Ember from 'ember';
+
+export default function beforeObserver(...args) {
+  var func  = args.slice(-1)[0];
+  var paths;
+
+  var addWatchedProperty = function(path) { paths.push(path); };
+
+  var _paths = args.slice(0, -1);
+
+  if (typeof func !== 'function') {
+    // revert to old, soft-deprecated argument ordering
+
+    func  = args[0];
+    _paths = args.slice(1);
+  }
+
+  paths = [];
+
+  for (var i = 0; i < _paths.length; ++i) {
+    Ember.expandProperties(_paths[i], addWatchedProperty);
+  }
+
+  if (typeof func !== 'function') {
+    throw new Ember.Error('Ember.beforeObserver called without a function');
+  }
+
+  func.__ember_observesBefore__ = paths;
+  return func;
+}

--- a/addon/utils/sortable-mixin.js
+++ b/addon/utils/sortable-mixin.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import beforeObserver from '../support/before-observer';
 
 const {
   get,
@@ -8,7 +9,6 @@ const {
   removeObserver,
   computed,
   Mixin,
-  beforeObserver,
   observer
 } = Ember;
 
@@ -159,7 +159,7 @@ export default Mixin.create(MutableEnumerable, {
     @property arrangedContent
     @private
   */
-  arrangedContent: computed('content', 'sortProperties.@each', {
+  arrangedContent: computed('content', 'sortProperties.[]', {
     get() {
       var content = get(this, 'content');
       var isSorted = get(this, 'isSorted');

--- a/bower.json
+++ b/bower.json
@@ -1,16 +1,19 @@
 {
   "name": "ember-legacy-controllers",
   "dependencies": {
-    "ember": "1.13.3",
+    "ember": "2.0.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.5",
+    "ember-data": "2.0.0-beta.2",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.4.1",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1"
+    "qunit": "~1.18.0"
+  },
+  "resolutions": {
+    "ember": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-cli-qunit": "0.3.15",
     "ember-cli-release": "0.2.3",
     "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.13.5",
+    "ember-data": "2.0.0-beta.2",
     "ember-export-application-global": "^1.0.2",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-try": "0.0.6",


### PR DESCRIPTION
Updated to use real Ember 2.0
- Fixed deprecated `sortProperties.@each` behaviour
- This functionality uses `beforeObserver` that is not in ember 2.0 anymore. Copy them into this addon?
